### PR TITLE
 Alioth: nfc: Disable forced firmware download to prevent HAL crash

### DIFF
--- a/proprietary/vendor/etc/libnfc-nxp.conf
+++ b/proprietary/vendor/etc/libnfc-nxp.conf
@@ -15,6 +15,7 @@ NXPLOG_NCIR_LOGLEVEL=0x03
 NXPLOG_FWDNLD_LOGLEVEL=0x03
 NXPLOG_TML_LOGLEVEL=0x03
 NFC_DEBUG_ENABLED=1
+NXP_FW_DWNLD_MODE=0x00
 
 ###############################################################################
 # Nfc Device Node name


### PR DESCRIPTION
Some devices experience a crash in the NXP NFC HAL during init, caused by the HAL attempting a forced firmware download. This patch sets:

 NXP_FW_DWNLD_MODE=0x00

in "vendor/etc/libnfc-nxp.conf" to disable forced firmware download.

* Prevents HAL SIGSEGV crashes on boot
* Safe fallback — uses embedded/default firmware
* Only affects NFC init behavior, no other vendor features changed